### PR TITLE
Fix: Icons not loading correctly due to content security policy

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' https://unpkg.com; script-src 'self' https://unpkg.com; style-src 'self' https://unpkg.com 'unsafe-inline'; img-src 'self' data:"
+      content="default-src 'self' https://unpkg.com https://cdn.jsdelivr.net; script-src 'self' https://unpkg.com https://cdn.jsdelivr.net; style-src 'self' https://unpkg.com https://cdn.jsdelivr.net 'unsafe-inline'; img-src 'self' data:"
     />
     <script src="https://unpkg.com/@phosphor-icons/web"></script>
   </head>


### PR DESCRIPTION
# Problem
Icons currently do not load in the current implementation, due to a Content Security Policy violation.
![image](https://github.com/user-attachments/assets/676ff95a-de9a-45dd-a5ed-d8f30c75ea91)

# Solution
Update Content-Security-Policy to allow loading stylesheets from `https://cdn.jsdelivr.net`
![image](https://github.com/user-attachments/assets/54aade92-daf5-474f-8765-70845f6f8d91)

Sorry if this issue was already mentioned somewhere or fixed somewhere else, I just saw this issue on my machine and decided to try and fix it